### PR TITLE
feat: add SQL defaults support with sqlDefault option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ export class User extends BaseEntity {
     @Column({ type: 'integer', nullable: true })
     age?: number;
 
-    @Column({ type: 'text', default: () => new Date().toISOString() })
-    createdAt!: string;
+    @Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
+    createdAt!: Date;
 }
 ```
 
@@ -160,7 +160,8 @@ await User.deleteAll({ status: 'inactive' });
     type: 'text' | 'integer' | 'real' | 'blob',  // SQLite data types
     nullable?: boolean,        // Allow NULL values (default: false)
     unique?: boolean,          // Add unique constraint (default: false)
-    default?: any | (() => any) // Default value or function
+    default?: any | (() => any), // JavaScript default value or function
+    sqlDefault?: string        // SQL default expression (e.g., 'CURRENT_TIMESTAMP')
 })
 ```
 
@@ -267,12 +268,43 @@ export class Post extends BaseEntity {
     @Column({ type: 'integer', default: 0 })
     viewCount!: number;
 
-    @Column({ type: 'text', default: () => new Date().toISOString() })
-    publishedAt!: string;
+    // SQL default - handled by SQLite
+    @Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
+    createdAt!: Date;
+
+    // JavaScript default - handled by application
+    @Column({ default: () => new Date() })
+    updatedAt!: Date;
 
     @Column({ type: 'text', default: () => JSON.stringify([]) })
     tags!: string; // Store JSON as text
 }
+```
+
+#### Default Value Options
+
+**SQL Defaults** (`sqlDefault`): Handled by SQLite in the database
+```typescript
+@Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
+createdAt!: Date;
+
+@Column({ sqlDefault: '0' })
+score!: number;
+
+@Column({ sqlDefault: "'active'" }) // Note the quotes for string literals
+status!: string;
+```
+
+**JavaScript Defaults** (`default`): Handled by the application
+```typescript
+@Column({ default: () => new Date() })
+updatedAt!: Date;
+
+@Column({ default: 'pending' })
+status!: string;
+
+@Column({ default: () => Math.random() })
+randomValue!: number;
 ```
 
 ### Error Handling

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,8 @@
 - ✅ `@PrimaryGeneratedColumn` for auto-increment IDs and UUID generation
 - ✅ `@PrimaryColumn` for custom primary keys
 - ✅ Column types (text, integer, real, blob) optimized for SQLite
-- ✅ Column options (nullable, unique, default values including functions)
+- ✅ Column options (nullable, unique, JavaScript defaults, SQL defaults)
+- ✅ SQL defaults (`sqlDefault`) with CURRENT_TIMESTAMP and custom expressions
 - ✅ TypeScript type inference and reflection-based metadata
 
 ### Active Record Pattern
@@ -25,6 +26,7 @@
 - ✅ SQL query generation optimized for SQLite syntax
 - ✅ Parameterized queries for SQL injection protection
 - ✅ Support for file-based and in-memory databases
+- ✅ SQL defaults with automatic entity reload after INSERT
 
 ### Auto Migrations
 - ✅ Automatic table creation from entity definitions

--- a/src/decorators/column.ts
+++ b/src/decorators/column.ts
@@ -28,6 +28,7 @@ export function Column(options: ColumnOptions = {}) {
             nullable: isNullable,
             unique: options.unique || false,
             default: options.default,
+            sqlDefault: options.sqlDefault,
             isPrimary: false,
             isGenerated: false,
         };

--- a/src/sql/sql-generator.ts
+++ b/src/sql/sql-generator.ts
@@ -23,7 +23,10 @@ export class SqlGenerator {
                 columnDef += ' UNIQUE';
             }
 
-            if (column.default !== undefined && typeof column.default !== 'function') {
+            // Handle SQL defaults first (takes precedence)
+            if (column.sqlDefault !== undefined) {
+                columnDef += ` DEFAULT ${column.sqlDefault}`;
+            } else if (column.default !== undefined && typeof column.default !== 'function') {
                 columnDef += ` DEFAULT ${this.formatDefaultValue(column.default)}`;
             }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,7 @@ export interface ColumnOptions {
     nullable?: boolean;
     unique?: boolean;
     default?: unknown;
+    sqlDefault?: string;
 }
 
 export interface EntityMetadata {
@@ -32,6 +33,7 @@ export interface ColumnMetadata {
     nullable: boolean;
     unique: boolean;
     default?: unknown;
+    sqlDefault?: string;
     isPrimary: boolean;
     isGenerated: boolean;
     generationStrategy?: 'increment' | 'uuid';

--- a/tests/integration/sql-defaults.test.ts
+++ b/tests/integration/sql-defaults.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from '../../src';
+import { DataSource } from '../../src/data-source';
+
+@Entity('sql_default_test')
+class SqlDefaultTestEntity extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column()
+    name!: string;
+
+    // SQL default - should use SQLite's CURRENT_TIMESTAMP
+    @Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
+    createdAt!: Date;
+
+    // JS default - should use JavaScript function
+    @Column({ default: () => new Date('2024-01-01') })
+    jsDefaultDate!: Date;
+
+    // Static default value
+    @Column({ default: 'active' })
+    status!: string;
+
+    // Mixed: SQL default takes precedence over JS default
+    @Column({ sqlDefault: 'CURRENT_TIMESTAMP', default: () => 'should not be used' })
+    mixedDefault!: Date;
+}
+
+describe('SQL Defaults Integration Tests', () => {
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        dataSource = new DataSource({
+            database: ':memory:',
+            entities: [SqlDefaultTestEntity],
+        });
+        await dataSource.initialize();
+        await dataSource.runMigrations(); // Create tables
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    test('should apply SQL CURRENT_TIMESTAMP default correctly', async () => {
+        const entity = new SqlDefaultTestEntity();
+        entity.name = 'Test Entity';
+
+        // Don't set createdAt - should use SQL default
+        expect(entity.createdAt).toBeUndefined();
+
+        await entity.save();
+
+        // After save, the entity should have a real timestamp from SQLite
+        expect(entity.id).toBeGreaterThan(0);
+        expect(entity.createdAt).toBeInstanceOf(Date);
+        expect(entity.createdAt.getTime()).toBeGreaterThan(new Date('2024-01-01').getTime());
+
+        // Verify the timestamp is recent (within last minute)
+        const now = new Date();
+        const timeDiff = now.getTime() - entity.createdAt.getTime();
+        expect(timeDiff).toBeLessThan(60000); // Less than 1 minute ago
+    });
+
+    test('should apply JS function defaults correctly', async () => {
+        const entity = new SqlDefaultTestEntity();
+        entity.name = 'Test JS Default';
+
+        await entity.save();
+
+        expect(entity.jsDefaultDate).toBeInstanceOf(Date);
+        expect(entity.jsDefaultDate.toISOString()).toContain('2024-01-01');
+    });
+
+    test('should apply static defaults correctly', async () => {
+        const entity = new SqlDefaultTestEntity();
+        entity.name = 'Test Static Default';
+
+        await entity.save();
+
+        expect(entity.status).toBe('active');
+    });
+
+    test('should prioritize SQL defaults over JS defaults when both present', async () => {
+        const entity = new SqlDefaultTestEntity();
+        entity.name = 'Test Mixed Default';
+
+        await entity.save();
+
+        // Should use SQL CURRENT_TIMESTAMP, not JS function returning string
+        expect(entity.mixedDefault).toBeInstanceOf(Date);
+        expect(entity.mixedDefault.getTime()).toBeGreaterThan(new Date('2024-01-01').getTime());
+    });
+
+    test('should allow manual values to override defaults', async () => {
+        const manualDate = new Date('2023-06-15');
+        const entity = new SqlDefaultTestEntity();
+        entity.name = 'Manual Override';
+        entity.createdAt = manualDate;
+        entity.status = 'inactive';
+
+        await entity.save();
+
+        expect(entity.createdAt.toISOString()).toContain('2023-06-15');
+        expect(entity.status).toBe('inactive');
+    });
+
+    test('should create correct DDL with SQL defaults', async () => {
+        // This tests that the SQL generator creates proper CREATE TABLE statements
+        // We can't easily inspect the DDL directly, but we can verify behavior
+
+        // Create multiple entities to ensure defaults work consistently
+        const entities = [];
+        for (let i = 0; i < 3; i++) {
+            const entity = new SqlDefaultTestEntity();
+            entity.name = `Batch Test ${i}`;
+            await entity.save();
+            entities.push(entity);
+        }
+
+        // All should have different timestamps (SQLite CURRENT_TIMESTAMP precision)
+        const timestamps = entities.map((e) => e.createdAt.getTime());
+        const uniqueTimestamps = new Set(timestamps);
+
+        // Due to SQLite's timestamp precision, we might get some duplicates
+        // but they should all be recent and in the right range
+        for (const timestamp of timestamps) {
+            expect(timestamp).toBeGreaterThan(new Date('2024-01-01').getTime());
+        }
+    });
+});


### PR DESCRIPTION
# SQL Defaults Support with `sqlDefault` Option

## Summary

This PR adds comprehensive support for SQL-level defaults through a new `sqlDefault` option in the `@Column` decorator, fixing the CURRENT_TIMESTAMP issue and providing a clear distinction between SQL defaults (handled by SQLite) and JavaScript defaults (handled by the application).

## Problem Statement

Users were experiencing issues with CURRENT_TIMESTAMP defaults where the literal string `'CURRENT_TIMESTAMP'` was being stored in the database instead of actual timestamps. This occurred because the ORM was calling JavaScript functions that returned strings rather than letting SQLite handle the timestamp generation.

**Previous broken behavior:**
```typescript
@Column({ default: () => 'CURRENT_TIMESTAMP' })
createdAt: Date; // Would store literal string "CURRENT_TIMESTAMP"
```

## Solution

Introduced a new `sqlDefault` option that allows developers to specify SQL expressions that should be handled directly by SQLite during table creation and data insertion.

**New working behavior:**
```typescript
@Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
createdAt: Date; // Stores actual timestamp: 2025-06-17T19:43:27.000Z
```

## Key Features

### 🎯 **SQL vs JavaScript Defaults**
- **`sqlDefault`**: SQL expressions handled by SQLite (e.g., `'CURRENT_TIMESTAMP'`, `'0'`, `"'active'"`)
- **`default`**: JavaScript values/functions handled by the application (e.g., `() => new Date()`, `'pending'`)

### 🔄 **Automatic Entity Reload**
- After INSERT operations, entities with SQL defaults automatically reload to fetch database-assigned values
- Ensures entity instances have the correct values that SQLite applied

### 🛡️ **Backward Compatibility**
- Existing `default` option continues to work unchanged
- No breaking changes to current applications
- Migration path is clear and optional

### 📝 **Type Safety**
- Full TypeScript support with proper type inference
- Date conversion handling for timestamp fields
- Comprehensive type definitions

## Examples

### SQL Defaults (Database-handled)
```typescript
@Entity('posts')
class Post extends BaseEntity {
    @PrimaryGeneratedColumn()
    id!: number;

    @Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
    createdAt!: Date;

    @Column({ sqlDefault: '0' })
    viewCount!: number;

    @Column({ sqlDefault: "'draft'" }) // Note quotes for string literals
    status!: string;
}
```

### JavaScript Defaults (Application-handled)
```typescript
@Entity('posts')
class Post extends BaseEntity {
    @Column({ default: () => new Date() })
    updatedAt!: Date;

    @Column({ default: 'pending' })
    status!: string;

    @Column({ default: () => Math.random() })
    randomValue!: number;
}
```

### Mixed Usage (SQL takes precedence)
```typescript
@Column({ 
    sqlDefault: 'CURRENT_TIMESTAMP', 
    default: () => 'should not be used' 
})
timestamp!: Date; // Uses SQL default
```

## Implementation Details

### Core Changes

1. **Type Definitions** (`src/types/index.ts`)
   - Added `sqlDefault?: string` to `ColumnOptions` and `ColumnMetadata`

2. **Column Decorator** (`src/decorators/column.ts`)
   - Extended to handle and store `sqlDefault` option

3. **SQL Generation** (`src/sql/sql-generator.ts`)
   - Prioritizes `sqlDefault` over `default` in DDL generation
   - Generates proper `DEFAULT` clauses in CREATE TABLE statements

4. **Entity Insertion** (`src/entity/base-entity.ts`)
   - Skips JavaScript function execution when `sqlDefault` is present
   - Automatically reloads entity after INSERT to fetch SQL defaults
   - Maintains existing behavior for JavaScript defaults

### Database Schema Generation

**Before:**
```sql
-- ❌ Missing SQL defaults
CREATE TABLE posts (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  title TEXT NOT NULL,
  created_at TEXT NOT NULL
);
```

**After:**
```sql
-- ✅ Proper SQL defaults
CREATE TABLE posts (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  title TEXT NOT NULL,
  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```

## Testing

### Comprehensive Test Coverage
- **Integration tests** for SQL defaults with real database operations
- **Unit tests** for SQL generation and decorator functionality
- **Edge case testing** for mixed defaults and precedence rules
- **Regression tests** to ensure backward compatibility

### Test Results
- ✅ All existing tests pass (no breaking changes)
- ✅ New SQL defaults tests comprehensive
- ✅ Performance impact minimal (only affects entities with SQL defaults)

## Documentation Updates

- ✅ **README.md**: Updated examples and Column Options reference
- ✅ **docs/features.md**: Added SQL defaults to completed features
- ✅ **Comprehensive examples** showing both SQL and JavaScript defaults
- ✅ **Migration guide** for updating existing CURRENT_TIMESTAMP usage

## Migration Guide

### For Existing CURRENT_TIMESTAMP Usage

**Before (problematic):**
```typescript
@Column({ default: () => 'CURRENT_TIMESTAMP' })
createdAt: Date;
```

**After (fixed):**
```typescript
@Column({ sqlDefault: 'CURRENT_TIMESTAMP' })
createdAt: Date;
```

### No Action Required
- Existing applications continue to work unchanged
- Migration is optional but recommended for timestamp fields
- JavaScript defaults (`default` option) remain fully functional

## Performance Impact

- **Minimal overhead**: Only affects INSERT operations for entities with SQL defaults
- **Single additional query**: SELECT to reload SQL defaults after INSERT
- **Optimized reloading**: Only executes when SQL defaults are present
- **No impact on updates**: Only INSERT operations trigger reload

## Breaking Changes

**None** - This is a purely additive feature that maintains full backward compatibility.

## Related Issues

- Fixes the CURRENT_TIMESTAMP literal string issue reported by users
- Addresses CodeRabbit feedback on default value handling
- Provides foundation for more advanced SQL default expressions

---

## Checklist

- ✅ All tests pass
- ✅ Documentation updated
- ✅ Backward compatibility maintained
- ✅ Type safety preserved
- ✅ Performance impact minimal
- ✅ Comprehensive test coverage added
- ✅ No breaking changes introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying SQL-level default values for entity columns, allowing use of SQL expressions like CURRENT_TIMESTAMP.
  - Entities now automatically reload after insertion to reflect SQL-applied default values.

- **Documentation**
  - Updated documentation to clarify the distinction between JavaScript and SQL default values, with new examples and explanations.

- **Tests**
  - Introduced integration tests to verify correct handling of SQL and JavaScript defaults, including precedence and behavior on entity creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->